### PR TITLE
added automatic calculation of direct sales to productionnumber

### DIFF
--- a/supplyChainSimulation/BuildXML.cs
+++ b/supplyChainSimulation/BuildXML.cs
@@ -193,11 +193,12 @@ namespace supplyChainSimulation
                 foreach (var product in modifiedArticelsfinalized)
                 {
                     int id = product.Item1;
-                    if (id < 100)
+                    int prodQuantity = product.Item2;
+                    if ((id < 100) & (prodQuantity > 0))
                     {
                         writer.WriteStartElement("production");
                         writer.WriteAttributeString("article", id.ToString());
-                        writer.WriteAttributeString("quantity", product.Item2.ToString());
+                        writer.WriteAttributeString("quantity", prodQuantity.ToString());
                         writer.WriteEndElement();
                     }
                 }

--- a/supplyChainSimulation/SalesProduction.Designer.cs
+++ b/supplyChainSimulation/SalesProduction.Designer.cs
@@ -431,6 +431,7 @@
             resources.ApplyResources(DirectXP3_0, "DirectXP3_0");
             DirectXP3_0.Maximum = new decimal(new int[] { 25000, 0, 0, 0 });
             DirectXP3_0.Name = "DirectXP3_0";
+            DirectXP3_0.ValueChanged += DirectXP3_0_ValueChanged;
             // 
             // DirectXP2_2
             // 
@@ -448,6 +449,7 @@
             resources.ApplyResources(DirectXP1_0, "DirectXP1_0");
             DirectXP1_0.Maximum = new decimal(new int[] { 25000, 0, 0, 0 });
             DirectXP1_0.Name = "DirectXP1_0";
+            DirectXP1_0.ValueChanged += DirectXP1_0_ValueChanged;
             // 
             // DirectXP2_1
             // 
@@ -472,6 +474,7 @@
             resources.ApplyResources(DirectXP2_0, "DirectXP2_0");
             DirectXP2_0.Maximum = new decimal(new int[] { 25000, 0, 0, 0 });
             DirectXP2_0.Name = "DirectXP2_0";
+            DirectXP2_0.ValueChanged += DirectXP2_0_ValueChanged;
             // 
             // label3
             // 

--- a/supplyChainSimulation/SalesProduction.cs
+++ b/supplyChainSimulation/SalesProduction.cs
@@ -56,6 +56,20 @@ namespace supplyChainSimulation
             Label_Period3_1.Text = $"{periodFormat} {current_period + 4}";
         }
 
+        // Der Event-Handler für ValueChanged
+        private void DirectXP1_0_ValueChanged(object sender, EventArgs e)
+        {
+            ProdXP1_0.Text = (forecast0[1] + DirectXP1_0.Value).ToString();
+        }
+        private void DirectXP2_0_ValueChanged(object sender, EventArgs e)
+        {
+            ProdXP2_0.Text = (forecast0[2] + DirectXP2_0.Value).ToString();
+        }
+        private void DirectXP3_0_ValueChanged(object sender, EventArgs e)
+        {
+            ProdXP3_0.Text = (forecast0[3] + DirectXP3_0.Value).ToString();
+        }
+
         private void switchToUpload_Click(object sender, EventArgs e)
         {
             MainOrchestrator mainOrchestrator = (MainOrchestrator)this.ParentForm;


### PR DESCRIPTION
Falls wir einen Zusatzauftrag bekommen, werden die Mengen des Zusatzauftrags automatisch zu den Produktionsmengen gezählt. Die Produktionsmenge kann aber dennoch noch manuell angepasst werden.

Kapere den Branch für kurzen Bugfix

Closes #52 